### PR TITLE
[#6] Add ability to ignore dirs for `gofmt`

### DIFF
--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -8,6 +8,11 @@ IGNORED_DIRS=""
 if [ -n "${GO_IGNORE_DIRS}" ]; then
   IGNORE_DIRS_ARR=($GO_IGNORE_DIRS)
   for DIR in "${IGNORE_DIRS_ARR[@]}"; do
+    # If the directory doesn't end in "/*", add it
+    if [[ ! "${DIR}" =~ .*\/\*$ ]]; then
+      DIR="${DIR}/*"
+    fi
+    # Append to our list of directories to ignore
    IGNORED_DIRS+=" -not -path \"${DIR}\""
   done
 fi

--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -17,6 +17,12 @@ if [ -n "${GO_IGNORE_DIRS}" ]; then
   done
 fi
 
+# Use an eval to avoid glob expansion
+FIND_EXEC="find . -type f -iname '*.go' ${IGNORED_DIRS}"
+
+# Get a list of files that we are interested in
+CHECK_FILES=$(eval ${FIND_EXEC})
+
 # Check if any files are not formatted.
 set +e
 test -z "$(gofmt -l -d -e $(find . -type f -iname '*.go' ${IGNORED_DIRS}))"

--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -3,6 +3,15 @@ set -e
 
 cd "${GO_WORKING_DIR:-.}"
 
+# Build ignored directories
+IGNORED_DIRS=""
+if [ -n "${GO_IGNORE_DIRS}" ]; then
+  IGNORE_DIRS_ARR=($GO_IGNORE_DIRS)
+  for DIR in "${IGNORE_DIRS_ARR[@]}"; do
+   IGNORED_DIRS+=" -not -path \"${DIR}\""
+  done
+fi
+
 # Check if any files are not formatted.
 set +e
 test -z "$(gofmt -l -d -e $(find . -type f -iname '*.go'))"

--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 cd "${GO_WORKING_DIR:-.}"

--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -14,7 +14,7 @@ fi
 
 # Check if any files are not formatted.
 set +e
-test -z "$(gofmt -l -d -e $(find . -type f -iname '*.go'))"
+test -z "$(gofmt -l -d -e $(find . -type f -iname '*.go' ${IGNORED_DIRS}))"
 SUCCESS=$?
 set -e
 

--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -25,7 +25,7 @@ CHECK_FILES=$(eval ${FIND_EXEC})
 
 # Check if any files are not formatted.
 set +e
-test -z "$(gofmt -l -d -e $(find . -type f -iname '*.go' ${IGNORED_DIRS}))"
+test -z "$(gofmt -l -d -e ${CHECK_FILES})"
 SUCCESS=$?
 set -e
 
@@ -36,16 +36,16 @@ fi
 
 # Get list of unformatted files.
 set +e
-FILES=$(sh -c "gofmt -l . $*" 2>&1)
-echo "$FILES"
+ISSUE_FILES=$(gofmt -l ${CHECK_FILES})
+echo "${ISSUE_FILES}"
 set -e
 
 # Iterate through each unformatted file.
 OUTPUT=""
-for file in $FILES; do
-DIFF=$(gofmt -d -e "$file")
+for FILE in $ISSUE_FILES; do
+DIFF=$(gofmt -d -e "${FILE}")
 OUTPUT="$OUTPUT
-\`$file\`
+\`${FILE}\`
 
 \`\`\`diff
 $DIFF

--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -13,7 +13,7 @@ if [ -n "${GO_IGNORE_DIRS}" ]; then
       DIR="${DIR}/*"
     fi
     # Append to our list of directories to ignore
-   IGNORED_DIRS+=" -not -path \"${DIR}\""
+    IGNORED_DIRS+=" -not -path \"${DIR}\""
   done
 fi
 


### PR DESCRIPTION
This PR tackles Issue #6 

This adds the ability to use the `GO_IGNORE_DIRS` environment variable to stop `gofmt` from checking, for example, `./vendor` directories.

Since the `golang:1.12` container has bash version 4, I'm switching the entrypoint to bash and utilising some nicer array and regex conditionals.

```
➜  go-github-actions (⎈) git:(6_fmt_ignore_dirs) ✗ docker run -it golang:1.12 bash
root@6cc0838de4df:/go# echo ${BASH_VERSION}
4.4.12(1)-release
root@6cc0838de4df:/go#
```

I did a quick test on a private repo and it seemed to work, but I also ran in to some unexplainable issues where it just "failed" after finishing the `action-runner:latest` Docker pull:
```
<snip>
165911d108d6: Pull complete
54996bce1de5: Pull complete
Digest: sha256:c9bb432ec5ec08ee08b040a9fccacebbbf8a91444dac4721600cf5dca9dae57e
Status: Downloaded newer image for gcr.io/github-actions-images/action-runner:latest

### FAILED Fmt 22:37:41Z (5.319s)
```

I'm pretty sure that has nothing to do with this image, as it didn't matter what I put in that Dockerfile.